### PR TITLE
Refactor config to use FastAPI dependency injection pattern

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ WORKDIR /app
 
 # Install dependencies
 RUN --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=bind,source=uv.lock,target=uv.lock \
-    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --locked --no-install-project --no-dev
+	--mount=type=bind,source=uv.lock,target=uv.lock \
+	--mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+	uv sync --locked --no-install-project --no-dev
 
 # Copy project files
 COPY ./pyproject.toml /app/pyproject.toml
@@ -16,7 +16,7 @@ COPY ./uv.lock /app/uv.lock
 
 # Install project
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-dev
+	uv sync --locked --no-dev
 
 
 FROM python:3.13-slim-bookworm
@@ -46,7 +46,7 @@ EXPOSE 8000
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD python -c "import httpx; httpx.get('http://localhost:8000/api/v1/health', timeout=5.0)"
+	CMD python -c "import httpx; httpx.get('http://localhost:8000/api/v1/health', timeout=5.0)"
 
 # Run the application
 CMD ["python", "-m", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ text-translation-service/
    ```
 
 3. **Get Google GenAI API key:**
+
    - Visit <https://aistudio.google.com/apikey>
    - Create/sign in to Google account and generate API key
    - Add to `.env` as `GOOGLE_API_KEY`
@@ -377,6 +378,7 @@ bash scripts/test.sh
 ```
 
 **See [tests/README.md](tests/README.md) for comprehensive testing guide** covering:
+
 - Test organization and structure
 - Fixtures and test doubles (FakeAssemblyAIClient, FakeS3Storage)
 - Running specific test suites

--- a/app/api/v1/health.py
+++ b/app/api/v1/health.py
@@ -1,8 +1,10 @@
 """Health check endpoints."""
 
-from fastapi import APIRouter, Response
+from typing import Annotated
 
-from app.core.config import settings
+from fastapi import APIRouter, Depends, Response
+
+from app.core.config import Settings, get_settings
 from app.schemas import HealthResponse
 from app.services.assemblyai_client import assemblyai_client
 from app.storage.s3 import s3_storage
@@ -12,7 +14,10 @@ router = APIRouter()
 
 @router.get("/", response_model=HealthResponse)
 @router.get("/health", response_model=HealthResponse)
-async def health_check(response: Response):
+async def health_check(
+    response: Response,
+    settings: Annotated[Settings, Depends(get_settings)],
+):
     """Health check endpoint with detailed component tests.
 
     Tests connectivity for all critical components: AssemblyAI, S3 storage.

--- a/app/api/v1/transcription.py
+++ b/app/api/v1/transcription.py
@@ -3,7 +3,6 @@
 import logging
 from pathlib import Path
 import secrets
-from typing import Annotated
 
 from fastapi import APIRouter, BackgroundTasks, Depends, File, Form, HTTPException, UploadFile
 from fastapi.responses import RedirectResponse

--- a/app/api/v1/transcription.py
+++ b/app/api/v1/transcription.py
@@ -3,12 +3,13 @@
 import logging
 from pathlib import Path
 import secrets
+from typing import Annotated
 
 from fastapi import APIRouter, BackgroundTasks, Depends, File, Form, HTTPException, UploadFile
 from fastapi.responses import RedirectResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.config import settings
+from app.core.config import Settings, get_settings
 from app.db import crud
 from app.db.base import get_db
 from app.db.models import JobStatus
@@ -31,6 +32,7 @@ async def create_transcription_job(
     language_detection: bool = Form(False, description="Enable automatic language detection"),
     speaker_labels: bool = Form(False, description="Enable speaker diarization"),
     session: AsyncSession = Depends(get_db),
+    settings: Settings = Depends(get_settings),
 ):
     """Create new transcription job.
 
@@ -272,6 +274,7 @@ async def get_transcription_status(
 async def get_transcription_srt(
     job_id: str,
     session: AsyncSession = Depends(get_db),
+    settings: Settings = Depends(get_settings),
 ):
     """Get transcription SRT file via 302 redirect to presigned S3 URL.
 
@@ -336,6 +339,7 @@ async def assemblyai_webhook(
     payload: AssemblyAIWebhookPayload,
     background_tasks: BackgroundTasks,
     session: AsyncSession = Depends(get_db),
+    settings: Settings = Depends(get_settings),
 ):
     """Handle AssemblyAI webhook completion notification.
 

--- a/app/api/v1/translation.py
+++ b/app/api/v1/translation.py
@@ -1,7 +1,10 @@
 """Translation endpoints."""
 
-from fastapi import APIRouter, HTTPException, status
+from typing import Annotated
 
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from app.core.config import Settings, get_settings
 from app.schemas import TranslationRequest, TranslationResponse
 from app.services.srt_parser import extract_texts, parse_srt, reconstruct_srt, update_texts
 from app.services.translation import GoogleGenAIError, translate_batch
@@ -16,7 +19,10 @@ router = APIRouter()
     summary="Translate SRT subtitle file",
     description="Translates SRT subtitle content while preserving timestamps and structure",
 )
-async def translate_srt(request: TranslationRequest):
+async def translate_srt(
+    request: TranslationRequest,
+    settings: Annotated[Settings, Depends(get_settings)],
+):
     """Translate SRT subtitle file to target language.
 
     Args:
@@ -47,6 +53,7 @@ async def translate_srt(request: TranslationRequest):
             "source_language": request.source_language,
             "country": request.country,
             "chunk_size": request.chunk_size,
+            "settings": settings,
         }
         if request.model:
             translate_params["model"] = request.model

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,5 +1,7 @@
 """Application configuration management."""
 
+from functools import lru_cache
+
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -82,5 +84,19 @@ class Settings(BaseSettings):
     )
 
 
-# Global settings instance
-settings = Settings()
+@lru_cache
+def get_settings() -> Settings:
+    """Get cached settings instance (singleton pattern).
+
+    Use as FastAPI dependency:
+        settings: Annotated[Settings, Depends(get_settings)]
+
+    Returns:
+        Settings: Cached settings instance
+    """
+    return Settings()
+
+
+# Module-level settings instance for backward compatibility
+# New code should use get_settings() for dependency injection
+settings = get_settings()

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -84,7 +84,7 @@ class Settings(BaseSettings):
     )
 
 
-@lru_cache
+@lru_cache(maxsize=1)
 def get_settings() -> Settings:
     """Get cached settings instance (singleton pattern).
 

--- a/app/core/logging.py
+++ b/app/core/logging.py
@@ -5,12 +5,14 @@ from logging.handlers import RotatingFileHandler
 from pathlib import Path
 import sys
 
-from app.core.config import settings
+from app.core.config import get_settings
 from app.core.log_filter import SensitiveDataFilter
 
 
 def setup_logging() -> None:
     """Configure application logging with stdout and rotating file handlers."""
+    settings = get_settings()
+
     # Create logs directory
     logs_dir = Path("./logs")
     logs_dir.mkdir(exist_ok=True)

--- a/app/core/middleware.py
+++ b/app/core/middleware.py
@@ -5,7 +5,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
 
-from app.core.config import settings
+from app.core.config import get_settings
 from app.core.security import AuthenticationMiddleware
 
 
@@ -15,6 +15,8 @@ def setup_middleware(app: FastAPI) -> None:
     Args:
         app: FastAPI application instance
     """
+    settings = get_settings()
+
     # CORS middleware
     if settings.cors_enabled:
         app.add_middleware(

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -4,7 +4,7 @@ from fastapi import Request, status
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 
-from app.core.config import settings
+from app.core.config import get_settings
 
 
 class AuthenticationMiddleware(BaseHTTPMiddleware):
@@ -12,6 +12,8 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next):
         """Validate API key for protected endpoints."""
+        settings = get_settings()
+
         # Skip auth for health check and docs endpoints
         if request.url.path in ["/", "/health", "/docs", "/openapi.json", "/redoc"]:
             return await call_next(request)

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -8,7 +8,7 @@ from sqlalchemy import event
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import DeclarativeBase
 
-from app.core.config import settings
+from app.core.config import get_settings
 
 logger = logging.getLogger(__name__)
 
@@ -19,17 +19,20 @@ class Base(DeclarativeBase):
     pass
 
 
+# Get settings at module level (cached via lru_cache)
+_settings = get_settings()
+
 # Create data directory if it doesn't exist
 DATA_DIR = Path("./data")
 DATA_DIR.mkdir(exist_ok=True)
 
 # Database URL
-DATABASE_URL = f"sqlite+aiosqlite:///{settings.database_path}"
+DATABASE_URL = f"sqlite+aiosqlite:///{_settings.database_path}"
 
 # Create async engine
 engine = create_async_engine(
     DATABASE_URL,
-    echo=settings.environment == "development",
+    echo=_settings.environment == "development",
     future=True,
     pool_pre_ping=True,  # Test connections before using them
 )

--- a/app/main.py
+++ b/app/main.py
@@ -8,7 +8,7 @@ import subprocess
 from fastapi import FastAPI
 
 from app.api.v1 import api_router
-from app.core.config import settings
+from app.core.config import get_settings
 from app.core.logging import setup_logging
 from app.core.middleware import setup_middleware
 from app.services.polling_service import polling_service
@@ -92,6 +92,7 @@ async def lifespan(app: FastAPI):
 
 def create_app() -> FastAPI:
     """Create and configure FastAPI application."""
+    settings = get_settings()
     app = FastAPI(
         title=settings.app_name,
         description=settings.app_description,
@@ -118,6 +119,7 @@ app = create_app()
 if __name__ == "__main__":
     import uvicorn
 
+    settings = get_settings()
     uvicorn.run(
         "app.main:app", host=settings.host, port=settings.port, proxy_headers=True, reload=False
     )

--- a/app/services/assemblyai_client.py
+++ b/app/services/assemblyai_client.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import assemblyai as aai
 
-from app.core.config import get_settings
+from app.core.config import Settings, get_settings
 
 logger = logging.getLogger(__name__)
 
@@ -15,13 +15,17 @@ logger = logging.getLogger(__name__)
 class AssemblyAIClient:
     """Client for interacting with AssemblyAI API."""
 
-    def __init__(self):
+    def __init__(self, settings: Settings | None = None):
         """Initialize AssemblyAI client (lazy initialization).
+
+        Args:
+            settings: Optional Settings instance (uses get_settings() if not provided)
 
         Client is initialized on first use via _ensure_initialized().
         """
         self._initialized = False
         self.transcriber: aai.Transcriber | None = None
+        self._settings = settings
 
     def _ensure_initialized(self):
         """Ensure client is initialized before use.
@@ -32,7 +36,7 @@ class AssemblyAIClient:
         if self._initialized:
             return
 
-        settings = get_settings()
+        settings = self._settings if self._settings is not None else get_settings()
         if not settings.assemblyai_api_key:
             raise ValueError("ASSEMBLYAI_API_KEY not configured")
 

--- a/app/services/assemblyai_client.py
+++ b/app/services/assemblyai_client.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import assemblyai as aai
 
-from app.core.config import settings
+from app.core.config import get_settings
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +32,7 @@ class AssemblyAIClient:
         if self._initialized:
             return
 
+        settings = get_settings()
         if not settings.assemblyai_api_key:
             raise ValueError("ASSEMBLYAI_API_KEY not configured")
 

--- a/app/services/assemblyai_client.py
+++ b/app/services/assemblyai_client.py
@@ -25,6 +25,9 @@ class AssemblyAIClient:
         """
         self._initialized = False
         self.transcriber: aai.Transcriber | None = None
+        # Resolve and store settings immediately for consistent behavior
+        if settings is None:
+            settings = get_settings()
         self._settings = settings
 
     def _ensure_initialized(self):
@@ -36,11 +39,10 @@ class AssemblyAIClient:
         if self._initialized:
             return
 
-        settings = self._settings if self._settings is not None else get_settings()
-        if not settings.assemblyai_api_key:
+        if not self._settings.assemblyai_api_key:
             raise ValueError("ASSEMBLYAI_API_KEY not configured")
 
-        aai.settings.api_key = settings.assemblyai_api_key
+        aai.settings.api_key = self._settings.assemblyai_api_key
         self.transcriber = aai.Transcriber()
         self._initialized = True
 

--- a/app/services/polling_service.py
+++ b/app/services/polling_service.py
@@ -3,7 +3,7 @@
 import asyncio
 import logging
 
-from app.core.config import settings
+from app.core.config import get_settings
 from app.db import crud
 from app.db.base import SessionLocal
 from app.services.transcription_service import process_completed_transcription
@@ -21,6 +21,7 @@ class PollingService:
 
     async def start(self) -> None:
         """Start the polling background task."""
+        settings = get_settings()
         if not settings.polling_enabled:
             logger.info("Polling disabled (POLLING_ENABLED=false)")
             return
@@ -56,6 +57,7 @@ class PollingService:
 
     async def _poll_loop(self) -> None:
         """Main polling loop that runs periodically."""
+        settings = get_settings()
         while not self._should_stop:
             try:
                 await self._poll_stale_jobs()
@@ -80,6 +82,7 @@ class PollingService:
         or polling) gets there first will process the job, and the second will
         skip it. This is intentional design, not a bug.
         """
+        settings = get_settings()
         async with SessionLocal() as session:
             try:
                 # Get stale jobs

--- a/app/services/polling_service.py
+++ b/app/services/polling_service.py
@@ -3,7 +3,7 @@
 import asyncio
 import logging
 
-from app.core.config import get_settings
+from app.core.config import Settings, get_settings
 from app.db import crud
 from app.db.base import SessionLocal
 from app.services.transcription_service import process_completed_transcription
@@ -14,14 +14,19 @@ logger = logging.getLogger(__name__)
 class PollingService:
     """Background service that polls for stale jobs and triggers recovery."""
 
-    def __init__(self):
-        """Initialize polling service."""
+    def __init__(self, settings: Settings | None = None):
+        """Initialize polling service.
+
+        Args:
+            settings: Optional Settings instance (uses get_settings() if not provided)
+        """
         self._task: asyncio.Task | None = None
         self._should_stop = False
+        self._settings = settings
 
     async def start(self) -> None:
         """Start the polling background task."""
-        settings = get_settings()
+        settings = self._settings if self._settings is not None else get_settings()
         if not settings.polling_enabled:
             logger.info("Polling disabled (POLLING_ENABLED=false)")
             return
@@ -57,7 +62,7 @@ class PollingService:
 
     async def _poll_loop(self) -> None:
         """Main polling loop that runs periodically."""
-        settings = get_settings()
+        settings = self._settings if self._settings is not None else get_settings()
         while not self._should_stop:
             try:
                 await self._poll_stale_jobs()
@@ -82,7 +87,7 @@ class PollingService:
         or polling) gets there first will process the job, and the second will
         skip it. This is intentional design, not a bug.
         """
-        settings = get_settings()
+        settings = self._settings if self._settings is not None else get_settings()
         async with SessionLocal() as session:
             try:
                 # Get stale jobs
@@ -118,7 +123,7 @@ class PollingService:
                         # Create new session for each job to avoid transaction conflicts
                         async with SessionLocal() as job_session:
                             await process_completed_transcription(
-                                job_session, job.id, job.assemblyai_id
+                                job_session, job.id, job.assemblyai_id, settings=settings
                             )
 
                         logger.info("Successfully recovered stale job %s", job.id)

--- a/app/services/transcription_service.py
+++ b/app/services/transcription_service.py
@@ -6,7 +6,7 @@ import logging
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.config import settings
+from app.core.config import get_settings
 from app.db import crud
 from app.db.models import JobStatus
 from app.services.assemblyai_client import assemblyai_client
@@ -50,6 +50,7 @@ async def process_completed_transcription(
         "Processing completed transcription for job %s (AssemblyAI: %s)", job_id, assemblyai_id
     )
 
+    settings = get_settings()
     max_attempts = settings.retry_max_attempts
     backoff_delays = settings.retry_backoff
 

--- a/app/services/transcription_service.py
+++ b/app/services/transcription_service.py
@@ -6,7 +6,7 @@ import logging
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.config import get_settings
+from app.core.config import Settings, get_settings
 from app.db import crud
 from app.db.models import JobStatus
 from app.services.assemblyai_client import assemblyai_client
@@ -32,7 +32,7 @@ def get_backoff_delay(retry_count: int, backoff_delays: list[int]) -> int:
 
 
 async def process_completed_transcription(
-    session: AsyncSession, job_id: str, assemblyai_id: str
+    session: AsyncSession, job_id: str, assemblyai_id: str, settings: Settings | None = None
 ) -> None:
     """Process completed transcription with retry logic.
 
@@ -45,12 +45,14 @@ async def process_completed_transcription(
         session: Database session
         job_id: Job ID
         assemblyai_id: AssemblyAI transcription ID
+        settings: Optional Settings instance (uses get_settings() if not provided)
     """
     logger.info(
         "Processing completed transcription for job %s (AssemblyAI: %s)", job_id, assemblyai_id
     )
 
-    settings = get_settings()
+    if settings is None:
+        settings = get_settings()
     max_attempts = settings.retry_max_attempts
     backoff_delays = settings.retry_backoff
 

--- a/app/storage/s3.py
+++ b/app/storage/s3.py
@@ -76,9 +76,10 @@ class S3Storage:
 
             # Test connectivity with HEAD bucket
             await self._client.head_bucket(Bucket=self.bucket)
+            settings = get_settings()
             logger.info(
                 "S3 client initialized successfully with connection pool (max_connections=%d)",
-                self.config.max_pool_connections,
+                settings.s3_max_pool_connections,
             )
             return True
         except ClientError as e:

--- a/app/storage/s3.py
+++ b/app/storage/s3.py
@@ -33,7 +33,8 @@ class S3Storage:
         Args:
             settings: Optional Settings instance (uses get_settings() if not provided)
         """
-        settings = settings if settings is not None else get_settings()
+        if settings is None:
+            settings = get_settings()
 
         self.session = aioboto3.Session()
         self.bucket = settings.s3_bucket_name

--- a/app/storage/s3.py
+++ b/app/storage/s3.py
@@ -8,7 +8,7 @@ from botocore.client import Config
 from botocore.exceptions import ClientError
 from fastapi import UploadFile
 
-from app.core.config import settings
+from app.core.config import get_settings
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +29,8 @@ class S3Storage:
 
     def __init__(self):
         """Initialize S3 storage configuration (does not create client)."""
+        settings = get_settings()
+
         self.session = aioboto3.Session()
         self.bucket = settings.s3_bucket_name
         self.endpoint_url = settings.s3_endpoint_url
@@ -76,7 +78,7 @@ class S3Storage:
             await self._client.head_bucket(Bucket=self.bucket)
             logger.info(
                 "S3 client initialized successfully with connection pool (max_connections=%d)",
-                settings.s3_max_pool_connections,
+                self.config.max_pool_connections,
             )
             return True
         except ClientError as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
     "aiosqlite>=0.19.0",
     "alembic>=1.13.0",
     "python-multipart>=0.0.6",
-    "boto3>=1.34.0",
     "aioboto3>=12.3.0",
 ]
 
@@ -28,7 +27,7 @@ dev = [
     "pytest-asyncio>=1.2.0",
     "pytest-cov>=7.0.0",
     "black>=25.9.0",
-    "ruff>=0.14.3",
+    "ruff>=0.14.4",
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,29 +5,29 @@ description = "SRT translation service using Google GenAI (Gemini 2.5 Pro)"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "fastapi>=0.121.0",
-    "uvicorn[standard]>=0.38.0",
-    "httpx>=0.28.1",
-    "pydantic>=2.12.4",
-    "pydantic-settings>=2.7.1",
-    "python-dotenv>=1.2.1",
-    "pysubs2>=1.7.0",
-    "google-genai>=1.49.0",
-    "assemblyai>=0.30.0",
-    "sqlalchemy>=2.0.0",
-    "aiosqlite>=0.19.0",
-    "alembic>=1.13.0",
-    "python-multipart>=0.0.6",
-    "aioboto3>=12.3.0",
+	"fastapi>=0.121.0",
+	"uvicorn[standard]>=0.38.0",
+	"httpx>=0.28.1",
+	"pydantic>=2.12.4",
+	"pydantic-settings>=2.11.0",
+	"python-dotenv>=1.2.1",
+	"pysubs2>=1.8.0",
+	"google-genai>=1.49.0",
+	"assemblyai>=0.46.0",
+	"sqlalchemy>=2.0.44",
+	"aiosqlite>=0.21.0",
+	"alembic>=1.17.1",
+	"python-multipart>=0.0.20",
+	"aioboto3>=15.5.0",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=8.4.2",
-    "pytest-asyncio>=1.2.0",
-    "pytest-cov>=7.0.0",
-    "black>=25.9.0",
-    "ruff>=0.14.4",
+	"pytest>=8.4.2",
+	"pytest-asyncio>=1.2.0",
+	"pytest-cov>=7.0.0",
+	"black>=25.9.0",
+	"ruff>=0.14.4",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/api/v1/test_transcription_direct.py
+++ b/tests/api/v1/test_transcription_direct.py
@@ -524,9 +524,7 @@ class TestGetTranscriptionSRTDirect:
         mock_settings = Settings(srt_presigned_url_expiry=3600)
 
         with pytest.raises(HTTPException) as exc_info:
-            await get_transcription_srt(
-                job_id=job.id, session=db_session, settings=mock_settings
-            )
+            await get_transcription_srt(job_id=job.id, session=db_session, settings=mock_settings)
         assert exc_info.value.status_code == 500
         assert "download url" in str(exc_info.value.detail).lower()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -163,8 +163,11 @@ def mock_translate_batch_error():
 @pytest.fixture
 def client_no_auth(mock_service_connectivity):
     """Client with no API key configured."""
-    with patch("app.core.security.settings") as mock_settings:
-        mock_settings.api_key = None
+    from app.core.config import Settings
+
+    mock_settings = Settings(api_key=None)
+    # Patch where get_settings is imported in security middleware
+    with patch("app.core.security.get_settings", return_value=mock_settings):
         app = create_app()
         yield TestClient(app)
 
@@ -172,8 +175,11 @@ def client_no_auth(mock_service_connectivity):
 @pytest.fixture
 def client_with_auth(mock_service_connectivity, init_test_db):
     """Client with API key configured (no default headers)."""
-    with patch("app.core.security.settings") as mock_settings:
-        mock_settings.api_key = "test_secret_key_12345"
+    from app.core.config import Settings
+
+    mock_settings = Settings(api_key="test_secret_key_12345")
+    # Patch where get_settings is imported in security middleware
+    with patch("app.core.security.get_settings", return_value=mock_settings):
         app = create_app()
         yield TestClient(app)
 

--- a/tests/services/test_transcription_service.py
+++ b/tests/services/test_transcription_service.py
@@ -399,7 +399,7 @@ class TestProcessCompletedTranscription:
     @patch("app.services.transcription_service.assemblyai_client")
     @patch("app.services.transcription_service.asyncio.sleep", new_callable=AsyncMock)
     async def test_exception_max_retries_reached(
-        self, mock_sleep, mock_aai, mock_crud, mock_get_settings
+        self, _mock_sleep, mock_aai, mock_crud, mock_get_settings
     ):
         """Test max retries reached after repeated exceptions."""
         mock_settings = Settings(retry_max_attempts=2, retry_backoff=[1, 2])
@@ -429,7 +429,7 @@ class TestProcessCompletedTranscription:
     @patch("app.services.transcription_service.s3_storage")
     @patch("app.services.transcription_service.asyncio.sleep", new_callable=AsyncMock)
     async def test_s3_upload_failure_with_retry(
-        self, mock_sleep, mock_s3, mock_aai, mock_crud, mock_get_settings
+        self, _mock_sleep, mock_s3, mock_aai, mock_crud, mock_get_settings
     ):
         """Test S3 upload failure triggers retry."""
         mock_settings = Settings(retry_max_attempts=2, retry_backoff=[1, 2])
@@ -465,7 +465,7 @@ class TestProcessCompletedTranscription:
     @patch("app.services.transcription_service.s3_storage")
     @patch("app.services.transcription_service.asyncio.sleep", new_callable=AsyncMock)
     async def test_convert_to_srt_failure_with_retry(
-        self, mock_sleep, mock_s3, mock_aai, mock_crud, mock_get_settings
+        self, _mock_sleep, _mock_s3, mock_aai, mock_crud, mock_get_settings
     ):
         """Test SRT conversion failure triggers retry."""
         mock_settings = Settings(retry_max_attempts=2, retry_backoff=[1, 2])
@@ -499,7 +499,7 @@ class TestProcessCompletedTranscription:
     @patch("app.services.transcription_service.assemblyai_client")
     @patch("app.services.transcription_service.s3_storage")
     async def test_session_rollback_on_exception(
-        self, mock_s3, mock_aai, mock_crud, mock_get_settings
+        self, _mock_s3, mock_aai, mock_crud, mock_get_settings
     ):
         """Test session rollback happens on exception."""
         mock_settings = Settings(retry_max_attempts=1, retry_backoff=[1])

--- a/tests/services/test_transcription_service.py
+++ b/tests/services/test_transcription_service.py
@@ -498,7 +498,9 @@ class TestProcessCompletedTranscription:
     @patch("app.services.transcription_service.crud")
     @patch("app.services.transcription_service.assemblyai_client")
     @patch("app.services.transcription_service.s3_storage")
-    async def test_session_rollback_on_exception(self, mock_s3, mock_aai, mock_crud, mock_get_settings):
+    async def test_session_rollback_on_exception(
+        self, mock_s3, mock_aai, mock_crud, mock_get_settings
+    ):
         """Test session rollback happens on exception."""
         mock_settings = Settings(retry_max_attempts=1, retry_backoff=[1])
         mock_get_settings.return_value = mock_settings

--- a/tests/services/test_translation.py
+++ b/tests/services/test_translation.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.core.config import Settings
 from app.services.translation import (
     GoogleGenAIError,
     translate_batch,
@@ -21,13 +22,13 @@ def mock_genai_client():
 
 @pytest.fixture
 def mock_settings():
-    """Mock settings with API key."""
-    with patch("app.services.translation.settings") as mock_settings:
-        mock_settings.google_api_key = "test_api_key"
-        mock_settings.default_model = "gemini-2.5-pro"
-        mock_settings.default_chunk_size = 100
-        mock_settings.max_concurrent_requests = 25
-        yield mock_settings
+    """Create mock Settings instance."""
+    return Settings(
+        google_api_key="test_api_key",
+        default_model="gemini-2.5-pro",
+        default_chunk_size=100,
+        max_concurrent_requests=25,
+    )
 
 
 class TestTranslateText:
@@ -47,7 +48,7 @@ class TestTranslateText:
         mock_genai_client.return_value = mock_instance
 
         # Test
-        result = await translate_text("Hello world", "Spanish")
+        result = await translate_text("Hello world", "Spanish", settings=mock_settings)
 
         assert result == "Hola mundo"
         mock_genai_client.assert_called_once_with(api_key="test_api_key")
@@ -64,7 +65,7 @@ class TestTranslateText:
         mock_instance.aio.models.generate_content = AsyncMock(return_value=mock_response)
         mock_genai_client.return_value = mock_instance
 
-        result = await translate_text("Hello", "French", source_language="English")
+        result = await translate_text("Hello", "French", source_language="English", settings=mock_settings)
 
         assert result == "Bonjour"
 
@@ -80,7 +81,7 @@ class TestTranslateText:
         mock_instance.aio.models.generate_content = AsyncMock(return_value=mock_response)
         mock_genai_client.return_value = mock_instance
 
-        result = await translate_text("Hello", "Portuguese", country="Brazil")
+        result = await translate_text("Hello", "Portuguese", country="Brazil", settings=mock_settings)
 
         assert result == "Olá"
 
@@ -99,18 +100,17 @@ class TestTranslateText:
         mock_instance.aio.models.generate_content = AsyncMock(return_value=mock_response)
         mock_genai_client.return_value = mock_instance
 
-        result = await translate_text("Test", "Spanish")
+        result = await translate_text("Test", "Spanish", settings=mock_settings)
 
         assert result == "Translation"
         assert "Thinking" not in result
 
     async def test_translate_text_no_api_key(self, mock_genai_client):
         """Test translation fails without API key."""
-        with patch("app.services.translation.settings") as mock_settings:
-            mock_settings.google_api_key = None
+        settings_no_key = Settings(google_api_key=None)
 
-            with pytest.raises(ValueError, match="GOOGLE_API_KEY not found"):
-                await translate_text("Test", "Spanish")
+        with pytest.raises(ValueError, match="GOOGLE_API_KEY not found"):
+            await translate_text("Test", "Spanish", settings=settings_no_key)
 
     async def test_translate_text_empty_response(self, mock_genai_client, mock_settings):
         """Test translation fails with empty response."""
@@ -126,7 +126,7 @@ class TestTranslateText:
         mock_genai_client.return_value = mock_instance
 
         with pytest.raises(GoogleGenAIError, match="No translation returned"):
-            await translate_text("Test", "Spanish")
+            await translate_text("Test", "Spanish", settings=mock_settings)
 
     async def test_translate_text_api_error(self, mock_genai_client, mock_settings):
         """Test translation handles API errors."""
@@ -135,7 +135,7 @@ class TestTranslateText:
         mock_genai_client.return_value = mock_instance
 
         with pytest.raises(GoogleGenAIError, match="Error during translation: API Error"):
-            await translate_text("Test", "Spanish")
+            await translate_text("Test", "Spanish", settings=mock_settings)
 
     async def test_translate_text_multiple_parts(self, mock_genai_client, mock_settings):
         """Test translation combines multiple text parts."""
@@ -152,7 +152,7 @@ class TestTranslateText:
         mock_instance.aio.models.generate_content = AsyncMock(return_value=mock_response)
         mock_genai_client.return_value = mock_instance
 
-        result = await translate_text("Test", "Spanish")
+        result = await translate_text("Test", "Spanish", settings=mock_settings)
 
         assert result == "Hello world"
 
@@ -181,7 +181,7 @@ class TestTranslateTextChunk:
         with patch("app.services.translation.uuid") as mock_uuid:
             mock_uuid.uuid4.return_value.hex = "12345678abcdef"
 
-            result = await translate_text_chunk(texts, "Spanish")
+            result = await translate_text_chunk(texts, "Spanish", settings=mock_settings)
 
         assert len(result) == 2
         assert result[0] == "Hola"
@@ -206,7 +206,7 @@ class TestTranslateTextChunk:
             mock_uuid.uuid4.return_value.hex = "12345678abcdef"
 
             with pytest.raises(GoogleGenAIError, match="Failed to parse entries: \\[2\\]"):
-                await translate_text_chunk(texts, "Spanish")
+                await translate_text_chunk(texts, "Spanish", settings=mock_settings)
 
     async def test_translate_chunk_duplicate_entry(self, mock_genai_client, mock_settings):
         """Test chunk translation fails with duplicate entries."""
@@ -230,7 +230,7 @@ class TestTranslateTextChunk:
             mock_uuid.uuid4.return_value.hex = "12345678abcdef"
 
             with pytest.raises(GoogleGenAIError, match="Duplicate entries detected: \\[1\\]"):
-                await translate_text_chunk(texts, "Spanish")
+                await translate_text_chunk(texts, "Spanish", settings=mock_settings)
 
     async def test_translate_chunk_reordered_entries(self, mock_genai_client, mock_settings):
         """Test chunk translation fails with reordered entries."""
@@ -254,7 +254,7 @@ class TestTranslateTextChunk:
             mock_uuid.uuid4.return_value.hex = "12345678abcdef"
 
             with pytest.raises(GoogleGenAIError, match="Entries are reordered"):
-                await translate_text_chunk(texts, "Spanish")
+                await translate_text_chunk(texts, "Spanish", settings=mock_settings)
 
     async def test_translate_chunk_delimiter_contamination(self, mock_genai_client, mock_settings):
         """Test chunk translation fails with delimiter in content."""
@@ -275,15 +275,14 @@ class TestTranslateTextChunk:
             mock_uuid.uuid4.return_value.hex = "12345678abcdef"
 
             with pytest.raises(GoogleGenAIError, match="Entry 1 contains delimiter-like content"):
-                await translate_text_chunk(texts, "Spanish")
+                await translate_text_chunk(texts, "Spanish", settings=mock_settings)
 
     async def test_translate_chunk_no_api_key(self, mock_genai_client):
         """Test chunk translation fails without API key."""
-        with patch("app.services.translation.settings") as mock_settings:
-            mock_settings.google_api_key = None
+        settings_no_key = Settings(google_api_key=None)
 
-            with pytest.raises(ValueError, match="GOOGLE_API_KEY not found"):
-                await translate_text_chunk(["Test"], "Spanish")
+        with pytest.raises(ValueError, match="GOOGLE_API_KEY not found"):
+            await translate_text_chunk(["Test"], "Spanish", settings=settings_no_key)
 
     async def test_translate_chunk_empty_response(self, mock_genai_client, mock_settings):
         """Test chunk translation fails with empty response."""
@@ -299,7 +298,7 @@ class TestTranslateTextChunk:
         mock_genai_client.return_value = mock_instance
 
         with pytest.raises(GoogleGenAIError, match="No translation returned"):
-            await translate_text_chunk(["Test"], "Spanish")
+            await translate_text_chunk(["Test"], "Spanish", settings=mock_settings)
 
     async def test_translate_chunk_with_logging(self, mock_genai_client, mock_settings):
         """Test chunk translation includes logging when indices provided."""
@@ -318,7 +317,7 @@ class TestTranslateTextChunk:
         with patch("app.services.translation.uuid") as mock_uuid:
             mock_uuid.uuid4.return_value.hex = "12345678abcdef"
 
-            result = await translate_text_chunk(texts, "Spanish", chunk_idx=1, total_chunks=5)
+            result = await translate_text_chunk(texts, "Spanish", chunk_idx=1, total_chunks=5, settings=mock_settings)
 
         assert result[0] == "Hola"
 
@@ -339,7 +338,7 @@ class TestTranslateTextChunk:
         with patch("app.services.translation.uuid") as mock_uuid:
             mock_uuid.uuid4.return_value.hex = "12345678abcdef"
 
-            result = await translate_text_chunk(texts, "Spanish")
+            result = await translate_text_chunk(texts, "Spanish", settings=mock_settings)
 
         # Whitespace is properly normalized (stripped)
         assert result[0] == "Hola"
@@ -362,7 +361,7 @@ class TestTranslateTextChunk:
         with patch("app.services.translation.uuid") as mock_uuid:
             mock_uuid.uuid4.return_value.hex = "12345678abcdef"
 
-            result = await translate_text_chunk(texts, "Spanish")
+            result = await translate_text_chunk(texts, "Spanish", settings=mock_settings)
 
         assert len(result) == 2
         assert result[0] == "Hola"
@@ -388,7 +387,7 @@ class TestTranslateTextChunk:
         with patch("app.services.translation.uuid") as mock_uuid:
             mock_uuid.uuid4.return_value.hex = "12345678abcdef"
 
-            result = await translate_text_chunk(texts, "Spanish")
+            result = await translate_text_chunk(texts, "Spanish", settings=mock_settings)
 
         assert result[0] == "Hola"
 
@@ -403,7 +402,7 @@ class TestTranslateTextChunk:
         with pytest.raises(
             GoogleGenAIError, match="Error during chunk translation: Network timeout"
         ):
-            await translate_text_chunk(["Test"], "Spanish")
+            await translate_text_chunk(["Test"], "Spanish", settings=mock_settings)
 
     async def test_translate_chunk_fallback_duplicate_no_session_id(
         self, mock_genai_client, mock_settings
@@ -426,7 +425,7 @@ class TestTranslateTextChunk:
             mock_uuid.uuid4.return_value.hex = "12345678abcdef"
 
             with pytest.raises(GoogleGenAIError, match="Duplicate entries detected: \\[1\\]"):
-                await translate_text_chunk(texts, "Spanish")
+                await translate_text_chunk(texts, "Spanish", settings=mock_settings)
 
     async def test_translate_chunk_count_mismatch_defensive_check(
         self, mock_genai_client, mock_settings
@@ -482,7 +481,7 @@ class TestTranslateBatch:
         with patch("app.services.translation.uuid") as mock_uuid:
             mock_uuid.uuid4.return_value.hex = "12345678abcdef"
 
-            result = await translate_batch(texts, "Spanish", chunk_size=10)
+            result = await translate_batch(texts, "Spanish", chunk_size=10, settings=mock_settings)
 
         assert len(result) == 2
         assert result == ["Hola", "Mundo"]
@@ -514,14 +513,14 @@ class TestTranslateBatch:
         with patch("app.services.translation.uuid") as mock_uuid:
             mock_uuid.uuid4.return_value.hex = "12345678abcdef"
 
-            result = await translate_batch(texts, "Spanish", chunk_size=1)
+            result = await translate_batch(texts, "Spanish", chunk_size=1, settings=mock_settings)
 
         assert len(result) == 3
         assert result == ["Uno", "Dos", "Tres"]
 
     async def test_translate_batch_empty_list(self, mock_genai_client, mock_settings):
         """Test batch translation with empty list."""
-        result = await translate_batch([], "Spanish")
+        result = await translate_batch([], "Spanish", settings=mock_settings)
 
         assert result == []
         mock_genai_client.assert_not_called()
@@ -556,7 +555,7 @@ class TestTranslateBatch:
         with patch("app.services.translation.uuid") as mock_uuid:
             mock_uuid.uuid4.return_value.hex = "12345678abcdef"
 
-            result = await translate_batch(texts, "Spanish", chunk_size=2)
+            result = await translate_batch(texts, "Spanish", chunk_size=2, settings=mock_settings)
 
         # Should make 3 calls: chunks of 2, 2, 1
         assert call_count == 3
@@ -585,7 +584,7 @@ class TestTranslateBatch:
         with patch("app.services.translation.uuid") as mock_uuid:
             mock_uuid.uuid4.return_value.hex = "12345678abcdef"
 
-            result = await translate_batch(texts, "Spanish", chunk_size=1, max_concurrent=3)
+            result = await translate_batch(texts, "Spanish", chunk_size=1, max_concurrent=3, settings=mock_settings)
 
         assert len(result) == 10
         assert call_count == 10
@@ -619,6 +618,6 @@ class TestTranslateBatch:
         with patch("app.services.translation.uuid") as mock_uuid:
             mock_uuid.uuid4.return_value.hex = "12345678abcdef"
 
-            result = await translate_batch(texts, "Spanish", chunk_size=1)
+            result = await translate_batch(texts, "Spanish", chunk_size=1, settings=mock_settings)
 
         assert result == ["1st", "2nd", "3rd"]

--- a/tests/services/test_translation.py
+++ b/tests/services/test_translation.py
@@ -65,7 +65,9 @@ class TestTranslateText:
         mock_instance.aio.models.generate_content = AsyncMock(return_value=mock_response)
         mock_genai_client.return_value = mock_instance
 
-        result = await translate_text("Hello", "French", source_language="English", settings=mock_settings)
+        result = await translate_text(
+            "Hello", "French", source_language="English", settings=mock_settings
+        )
 
         assert result == "Bonjour"
 
@@ -81,7 +83,9 @@ class TestTranslateText:
         mock_instance.aio.models.generate_content = AsyncMock(return_value=mock_response)
         mock_genai_client.return_value = mock_instance
 
-        result = await translate_text("Hello", "Portuguese", country="Brazil", settings=mock_settings)
+        result = await translate_text(
+            "Hello", "Portuguese", country="Brazil", settings=mock_settings
+        )
 
         assert result == "Olá"
 
@@ -317,7 +321,9 @@ class TestTranslateTextChunk:
         with patch("app.services.translation.uuid") as mock_uuid:
             mock_uuid.uuid4.return_value.hex = "12345678abcdef"
 
-            result = await translate_text_chunk(texts, "Spanish", chunk_idx=1, total_chunks=5, settings=mock_settings)
+            result = await translate_text_chunk(
+                texts, "Spanish", chunk_idx=1, total_chunks=5, settings=mock_settings
+            )
 
         assert result[0] == "Hola"
 
@@ -584,7 +590,9 @@ class TestTranslateBatch:
         with patch("app.services.translation.uuid") as mock_uuid:
             mock_uuid.uuid4.return_value.hex = "12345678abcdef"
 
-            result = await translate_batch(texts, "Spanish", chunk_size=1, max_concurrent=3, settings=mock_settings)
+            result = await translate_batch(
+                texts, "Spanish", chunk_size=1, max_concurrent=3, settings=mock_settings
+            )
 
         assert len(result) == 10
         assert call_count == 10

--- a/tests/storage/test_s3.py
+++ b/tests/storage/test_s3.py
@@ -6,23 +6,26 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from botocore.exceptions import ClientError
 import pytest
 
+from app.core.config import Settings
 from app.storage.s3 import S3ClientNotInitializedError, S3Storage
 
 
 class TestS3StorageInitialization:
     """Test S3Storage initialization."""
 
-    @patch("app.storage.s3.settings")
-    def test_init(self, mock_settings):
+    @patch("app.storage.s3.get_settings")
+    def test_init(self, mock_get_settings):
         """Test basic initialization."""
-        mock_settings.s3_bucket_name = "test-bucket"
-        mock_settings.s3_endpoint_url = None
-        mock_settings.s3_region = "us-east-1"
-        mock_settings.s3_access_key_id = "test-key"
-        mock_settings.s3_secret_access_key = "test-secret"
-        mock_settings.s3_max_pool_connections = 10
-        mock_settings.s3_connect_timeout = 5
-        mock_settings.s3_read_timeout = 60
+        mock_settings = Settings(
+            s3_bucket_name="test-bucket",
+            s3_region="us-east-1",
+            s3_access_key_id="test-key",
+            s3_secret_access_key="test-secret",
+            s3_max_pool_connections=10,
+            s3_connect_timeout=5,
+            s3_read_timeout=60,
+        )
+        mock_get_settings.return_value = mock_settings
 
         storage = S3Storage()
 
@@ -32,17 +35,19 @@ class TestS3StorageInitialization:
         assert storage._client_context is None
 
     @pytest.mark.asyncio
-    @patch("app.storage.s3.settings")
-    async def test_initialize_success(self, mock_settings):
+    @patch("app.storage.s3.get_settings")
+    async def test_initialize_success(self, mock_get_settings):
         """Test successful S3 client initialization."""
-        mock_settings.s3_bucket_name = "test-bucket"
-        mock_settings.s3_endpoint_url = None
-        mock_settings.s3_region = "us-east-1"
-        mock_settings.s3_access_key_id = "test-key"
-        mock_settings.s3_secret_access_key = "test-secret"
-        mock_settings.s3_max_pool_connections = 10
-        mock_settings.s3_connect_timeout = 5
-        mock_settings.s3_read_timeout = 60
+        mock_settings = Settings(
+            s3_bucket_name="test-bucket",
+            s3_region="us-east-1",
+            s3_access_key_id="test-key",
+            s3_secret_access_key="test-secret",
+            s3_max_pool_connections=10,
+            s3_connect_timeout=5,
+            s3_read_timeout=60,
+        )
+        mock_get_settings.return_value = mock_settings
 
         storage = S3Storage()
 
@@ -63,17 +68,19 @@ class TestS3StorageInitialization:
         mock_client.head_bucket.assert_called_once_with(Bucket="test-bucket")
 
     @pytest.mark.asyncio
-    @patch("app.storage.s3.settings")
-    async def test_initialize_client_error(self, mock_settings):
+    @patch("app.storage.s3.get_settings")
+    async def test_initialize_client_error(self, mock_get_settings):
         """Test initialization failure with ClientError."""
-        mock_settings.s3_bucket_name = "test-bucket"
-        mock_settings.s3_endpoint_url = None
-        mock_settings.s3_region = "us-east-1"
-        mock_settings.s3_access_key_id = "bad-key"
-        mock_settings.s3_secret_access_key = "bad-secret"
-        mock_settings.s3_max_pool_connections = 10
-        mock_settings.s3_connect_timeout = 5
-        mock_settings.s3_read_timeout = 60
+        mock_settings = Settings(
+            s3_bucket_name="test-bucket",
+            s3_region="us-east-1",
+            s3_access_key_id="bad-key",
+            s3_secret_access_key="bad-secret",
+            s3_max_pool_connections=10,
+            s3_connect_timeout=5,
+            s3_read_timeout=60,
+        )
+        mock_get_settings.return_value = mock_settings
 
         storage = S3Storage()
 
@@ -91,17 +98,19 @@ class TestS3StorageInitialization:
         assert storage._client is None
 
     @pytest.mark.asyncio
-    @patch("app.storage.s3.settings")
-    async def test_initialize_generic_error(self, mock_settings):
+    @patch("app.storage.s3.get_settings")
+    async def test_initialize_generic_error(self, mock_get_settings):
         """Test initialization failure with generic exception."""
-        mock_settings.s3_bucket_name = "test-bucket"
-        mock_settings.s3_endpoint_url = None
-        mock_settings.s3_region = "us-east-1"
-        mock_settings.s3_access_key_id = "test-key"
-        mock_settings.s3_secret_access_key = "test-secret"
-        mock_settings.s3_max_pool_connections = 10
-        mock_settings.s3_connect_timeout = 5
-        mock_settings.s3_read_timeout = 60
+        mock_settings = Settings(
+            s3_bucket_name="test-bucket",
+            s3_region="us-east-1",
+            s3_access_key_id="test-key",
+            s3_secret_access_key="test-secret",
+            s3_max_pool_connections=10,
+            s3_connect_timeout=5,
+            s3_read_timeout=60,
+        )
+        mock_get_settings.return_value = mock_settings
 
         storage = S3Storage()
 
@@ -113,13 +122,16 @@ class TestS3StorageInitialization:
         assert storage._client is None
 
     @pytest.mark.asyncio
-    @patch("app.storage.s3.settings")
-    async def test_close(self, mock_settings):
+    @patch("app.storage.s3.get_settings")
+    async def test_close(self, mock_get_settings):
         """Test closing S3 client."""
-        mock_settings.s3_bucket_name = "test-bucket"
-        mock_settings.s3_max_pool_connections = 10
-        mock_settings.s3_connect_timeout = 5
-        mock_settings.s3_read_timeout = 60
+        mock_settings = Settings(
+            s3_bucket_name="test-bucket",
+            s3_max_pool_connections=10,
+            s3_connect_timeout=5,
+            s3_read_timeout=60,
+        )
+        mock_get_settings.return_value = mock_settings
 
         storage = S3Storage()
 
@@ -138,13 +150,16 @@ class TestS3StorageInitialization:
         mock_client_context.__aexit__.assert_called_once()
 
     @pytest.mark.asyncio
-    @patch("app.storage.s3.settings")
-    async def test_close_with_error(self, mock_settings):
+    @patch("app.storage.s3.get_settings")
+    async def test_close_with_error(self, mock_get_settings):
         """Test closing S3 client when error occurs."""
-        mock_settings.s3_bucket_name = "test-bucket"
-        mock_settings.s3_max_pool_connections = 10
-        mock_settings.s3_connect_timeout = 5
-        mock_settings.s3_read_timeout = 60
+        mock_settings = Settings(
+            s3_bucket_name="test-bucket",
+            s3_max_pool_connections=10,
+            s3_connect_timeout=5,
+            s3_read_timeout=60,
+        )
+        mock_get_settings.return_value = mock_settings
 
         storage = S3Storage()
 
@@ -165,13 +180,16 @@ class TestS3StorageInitialization:
 class TestEnsureInitialized:
     """Test _ensure_initialized method."""
 
-    @patch("app.storage.s3.settings")
-    def test_ensure_initialized_success(self, mock_settings):
+    @patch("app.storage.s3.get_settings")
+    def test_ensure_initialized_success(self, mock_get_settings):
         """Test ensure initialized when client exists."""
-        mock_settings.s3_bucket_name = "test-bucket"
-        mock_settings.s3_max_pool_connections = 10
-        mock_settings.s3_connect_timeout = 5
-        mock_settings.s3_read_timeout = 60
+        mock_settings = Settings(
+            s3_bucket_name="test-bucket",
+            s3_max_pool_connections=10,
+            s3_connect_timeout=5,
+            s3_read_timeout=60,
+        )
+        mock_get_settings.return_value = mock_settings
 
         storage = S3Storage()
         storage._client = AsyncMock()
@@ -179,13 +197,16 @@ class TestEnsureInitialized:
         # Should not raise
         storage._ensure_initialized()
 
-    @patch("app.storage.s3.settings")
-    def test_ensure_initialized_not_initialized(self, mock_settings):
+    @patch("app.storage.s3.get_settings")
+    def test_ensure_initialized_not_initialized(self, mock_get_settings):
         """Test ensure initialized when client not initialized."""
-        mock_settings.s3_bucket_name = "test-bucket"
-        mock_settings.s3_max_pool_connections = 10
-        mock_settings.s3_connect_timeout = 5
-        mock_settings.s3_read_timeout = 60
+        mock_settings = Settings(
+            s3_bucket_name="test-bucket",
+            s3_max_pool_connections=10,
+            s3_connect_timeout=5,
+            s3_read_timeout=60,
+        )
+        mock_get_settings.return_value = mock_settings
 
         storage = S3Storage()
 
@@ -197,13 +218,16 @@ class TestUploadAudio:
     """Test upload_audio method."""
 
     @pytest.mark.asyncio
-    @patch("app.storage.s3.settings")
-    async def test_upload_audio_success(self, mock_settings):
+    @patch("app.storage.s3.get_settings")
+    async def test_upload_audio_success(self, mock_get_settings):
         """Test successful audio upload."""
-        mock_settings.s3_bucket_name = "test-bucket"
-        mock_settings.s3_max_pool_connections = 10
-        mock_settings.s3_connect_timeout = 5
-        mock_settings.s3_read_timeout = 60
+        mock_settings = Settings(
+            s3_bucket_name="test-bucket",
+            s3_max_pool_connections=10,
+            s3_connect_timeout=5,
+            s3_read_timeout=60,
+        )
+        mock_get_settings.return_value = mock_settings
 
         storage = S3Storage()
 
@@ -224,13 +248,16 @@ class TestUploadAudio:
         mock_client.upload_fileobj.assert_called_once()
 
     @pytest.mark.asyncio
-    @patch("app.storage.s3.settings")
-    async def test_upload_audio_not_initialized(self, mock_settings):
+    @patch("app.storage.s3.get_settings")
+    async def test_upload_audio_not_initialized(self, mock_get_settings):
         """Test upload audio when client not initialized."""
-        mock_settings.s3_bucket_name = "test-bucket"
-        mock_settings.s3_max_pool_connections = 10
-        mock_settings.s3_connect_timeout = 5
-        mock_settings.s3_read_timeout = 60
+        mock_settings = Settings(
+            s3_bucket_name="test-bucket",
+            s3_max_pool_connections=10,
+            s3_connect_timeout=5,
+            s3_read_timeout=60,
+        )
+        mock_get_settings.return_value = mock_settings
 
         storage = S3Storage()
 
@@ -241,13 +268,16 @@ class TestUploadAudio:
             await storage.upload_audio("job-123", mock_file)
 
     @pytest.mark.asyncio
-    @patch("app.storage.s3.settings")
-    async def test_upload_audio_failure(self, mock_settings):
+    @patch("app.storage.s3.get_settings")
+    async def test_upload_audio_failure(self, mock_get_settings):
         """Test upload audio failure."""
-        mock_settings.s3_bucket_name = "test-bucket"
-        mock_settings.s3_max_pool_connections = 10
-        mock_settings.s3_connect_timeout = 5
-        mock_settings.s3_read_timeout = 60
+        mock_settings = Settings(
+            s3_bucket_name="test-bucket",
+            s3_max_pool_connections=10,
+            s3_connect_timeout=5,
+            s3_read_timeout=60,
+        )
+        mock_get_settings.return_value = mock_settings
 
         storage = S3Storage()
 
@@ -269,13 +299,16 @@ class TestUploadSRT:
     """Test upload_srt method."""
 
     @pytest.mark.asyncio
-    @patch("app.storage.s3.settings")
-    async def test_upload_srt_success(self, mock_settings):
+    @patch("app.storage.s3.get_settings")
+    async def test_upload_srt_success(self, mock_get_settings):
         """Test successful SRT upload."""
-        mock_settings.s3_bucket_name = "test-bucket"
-        mock_settings.s3_max_pool_connections = 10
-        mock_settings.s3_connect_timeout = 5
-        mock_settings.s3_read_timeout = 60
+        mock_settings = Settings(
+            s3_bucket_name="test-bucket",
+            s3_max_pool_connections=10,
+            s3_connect_timeout=5,
+            s3_read_timeout=60,
+        )
+        mock_get_settings.return_value = mock_settings
 
         storage = S3Storage()
 
@@ -293,13 +326,16 @@ class TestUploadSRT:
         assert call_args[1]["ContentType"] == "text/plain; charset=utf-8"
 
     @pytest.mark.asyncio
-    @patch("app.storage.s3.settings")
-    async def test_upload_srt_not_initialized(self, mock_settings):
+    @patch("app.storage.s3.get_settings")
+    async def test_upload_srt_not_initialized(self, mock_get_settings):
         """Test upload SRT when client not initialized."""
-        mock_settings.s3_bucket_name = "test-bucket"
-        mock_settings.s3_max_pool_connections = 10
-        mock_settings.s3_connect_timeout = 5
-        mock_settings.s3_read_timeout = 60
+        mock_settings = Settings(
+            s3_bucket_name="test-bucket",
+            s3_max_pool_connections=10,
+            s3_connect_timeout=5,
+            s3_read_timeout=60,
+        )
+        mock_get_settings.return_value = mock_settings
 
         storage = S3Storage()
 
@@ -307,13 +343,16 @@ class TestUploadSRT:
             await storage.upload_srt("job-123", "test content")
 
     @pytest.mark.asyncio
-    @patch("app.storage.s3.settings")
-    async def test_upload_srt_failure(self, mock_settings):
+    @patch("app.storage.s3.get_settings")
+    async def test_upload_srt_failure(self, mock_get_settings):
         """Test upload SRT failure."""
-        mock_settings.s3_bucket_name = "test-bucket"
-        mock_settings.s3_max_pool_connections = 10
-        mock_settings.s3_connect_timeout = 5
-        mock_settings.s3_read_timeout = 60
+        mock_settings = Settings(
+            s3_bucket_name="test-bucket",
+            s3_max_pool_connections=10,
+            s3_connect_timeout=5,
+            s3_read_timeout=60,
+        )
+        mock_get_settings.return_value = mock_settings
 
         storage = S3Storage()
 
@@ -329,13 +368,16 @@ class TestGeneratePresignedURL:
     """Test generate_presigned_url method."""
 
     @pytest.mark.asyncio
-    @patch("app.storage.s3.settings")
-    async def test_generate_presigned_url_success(self, mock_settings):
+    @patch("app.storage.s3.get_settings")
+    async def test_generate_presigned_url_success(self, mock_get_settings):
         """Test successful presigned URL generation."""
-        mock_settings.s3_bucket_name = "test-bucket"
-        mock_settings.s3_max_pool_connections = 10
-        mock_settings.s3_connect_timeout = 5
-        mock_settings.s3_read_timeout = 60
+        mock_settings = Settings(
+            s3_bucket_name="test-bucket",
+            s3_max_pool_connections=10,
+            s3_connect_timeout=5,
+            s3_read_timeout=60,
+        )
+        mock_get_settings.return_value = mock_settings
 
         storage = S3Storage()
 
@@ -356,13 +398,16 @@ class TestGeneratePresignedURL:
         )
 
     @pytest.mark.asyncio
-    @patch("app.storage.s3.settings")
-    async def test_generate_presigned_url_not_initialized(self, mock_settings):
+    @patch("app.storage.s3.get_settings")
+    async def test_generate_presigned_url_not_initialized(self, mock_get_settings):
         """Test presigned URL generation when client not initialized."""
-        mock_settings.s3_bucket_name = "test-bucket"
-        mock_settings.s3_max_pool_connections = 10
-        mock_settings.s3_connect_timeout = 5
-        mock_settings.s3_read_timeout = 60
+        mock_settings = Settings(
+            s3_bucket_name="test-bucket",
+            s3_max_pool_connections=10,
+            s3_connect_timeout=5,
+            s3_read_timeout=60,
+        )
+        mock_get_settings.return_value = mock_settings
 
         storage = S3Storage()
 
@@ -370,13 +415,16 @@ class TestGeneratePresignedURL:
             await storage.generate_presigned_url("srt/test.srt", 3600)
 
     @pytest.mark.asyncio
-    @patch("app.storage.s3.settings")
-    async def test_generate_presigned_url_failure(self, mock_settings):
+    @patch("app.storage.s3.get_settings")
+    async def test_generate_presigned_url_failure(self, mock_get_settings):
         """Test presigned URL generation failure."""
-        mock_settings.s3_bucket_name = "test-bucket"
-        mock_settings.s3_max_pool_connections = 10
-        mock_settings.s3_connect_timeout = 5
-        mock_settings.s3_read_timeout = 60
+        mock_settings = Settings(
+            s3_bucket_name="test-bucket",
+            s3_max_pool_connections=10,
+            s3_connect_timeout=5,
+            s3_read_timeout=60,
+        )
+        mock_get_settings.return_value = mock_settings
 
         storage = S3Storage()
 
@@ -392,13 +440,16 @@ class TestConnectivity:
     """Test test_connectivity method."""
 
     @pytest.mark.asyncio
-    @patch("app.storage.s3.settings")
-    async def test_connectivity_success(self, mock_settings):
+    @patch("app.storage.s3.get_settings")
+    async def test_connectivity_success(self, mock_get_settings):
         """Test successful connectivity check."""
-        mock_settings.s3_bucket_name = "test-bucket"
-        mock_settings.s3_max_pool_connections = 10
-        mock_settings.s3_connect_timeout = 5
-        mock_settings.s3_read_timeout = 60
+        mock_settings = Settings(
+            s3_bucket_name="test-bucket",
+            s3_max_pool_connections=10,
+            s3_connect_timeout=5,
+            s3_read_timeout=60,
+        )
+        mock_get_settings.return_value = mock_settings
 
         storage = S3Storage()
 
@@ -412,13 +463,16 @@ class TestConnectivity:
         mock_client.head_bucket.assert_called_once_with(Bucket="test-bucket")
 
     @pytest.mark.asyncio
-    @patch("app.storage.s3.settings")
-    async def test_connectivity_not_initialized(self, mock_settings):
+    @patch("app.storage.s3.get_settings")
+    async def test_connectivity_not_initialized(self, mock_get_settings):
         """Test connectivity check when client not initialized."""
-        mock_settings.s3_bucket_name = "test-bucket"
-        mock_settings.s3_max_pool_connections = 10
-        mock_settings.s3_connect_timeout = 5
-        mock_settings.s3_read_timeout = 60
+        mock_settings = Settings(
+            s3_bucket_name="test-bucket",
+            s3_max_pool_connections=10,
+            s3_connect_timeout=5,
+            s3_read_timeout=60,
+        )
+        mock_get_settings.return_value = mock_settings
 
         storage = S3Storage()
 
@@ -427,13 +481,16 @@ class TestConnectivity:
         assert result is False
 
     @pytest.mark.asyncio
-    @patch("app.storage.s3.settings")
-    async def test_connectivity_failure(self, mock_settings):
+    @patch("app.storage.s3.get_settings")
+    async def test_connectivity_failure(self, mock_get_settings):
         """Test connectivity check failure."""
-        mock_settings.s3_bucket_name = "test-bucket"
-        mock_settings.s3_max_pool_connections = 10
-        mock_settings.s3_connect_timeout = 5
-        mock_settings.s3_read_timeout = 60
+        mock_settings = Settings(
+            s3_bucket_name="test-bucket",
+            s3_max_pool_connections=10,
+            s3_connect_timeout=5,
+            s3_read_timeout=60,
+        )
+        mock_get_settings.return_value = mock_settings
 
         storage = S3Storage()
 

--- a/uv.lock
+++ b/uv.lock
@@ -1305,24 +1305,24 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aioboto3", specifier = ">=12.3.0" },
-    { name = "aiosqlite", specifier = ">=0.19.0" },
-    { name = "alembic", specifier = ">=1.13.0" },
-    { name = "assemblyai", specifier = ">=0.30.0" },
+    { name = "aioboto3", specifier = ">=15.5.0" },
+    { name = "aiosqlite", specifier = ">=0.21.0" },
+    { name = "alembic", specifier = ">=1.17.1" },
+    { name = "assemblyai", specifier = ">=0.46.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=25.9.0" },
     { name = "fastapi", specifier = ">=0.121.0" },
     { name = "google-genai", specifier = ">=1.49.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pydantic", specifier = ">=2.12.4" },
-    { name = "pydantic-settings", specifier = ">=2.7.1" },
-    { name = "pysubs2", specifier = ">=1.7.0" },
+    { name = "pydantic-settings", specifier = ">=2.11.0" },
+    { name = "pysubs2", specifier = ">=1.8.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.2" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.2.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
-    { name = "python-multipart", specifier = ">=0.0.6" },
+    { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.4" },
-    { name = "sqlalchemy", specifier = ">=2.0.0" },
+    { name = "sqlalchemy", specifier = ">=2.0.44" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.38.0" },
 ]
 provides-extras = ["dev"]

--- a/uv.lock
+++ b/uv.lock
@@ -1177,28 +1177,28 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.14.3"
+version = "0.14.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/75/62/50b7727004dfe361104dfbf898c45a9a2fdfad8c72c04ae62900224d6ecf/ruff-0.14.3.tar.gz", hash = "sha256:4ff876d2ab2b161b6de0aa1f5bd714e8e9b4033dc122ee006925fbacc4f62153", size = 5558687, upload-time = "2025-10-31T00:26:26.878Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/55/cccfca45157a2031dcbb5a462a67f7cf27f8b37d4b3b1cd7438f0f5c1df6/ruff-0.14.4.tar.gz", hash = "sha256:f459a49fe1085a749f15414ca76f61595f1a2cc8778ed7c279b6ca2e1fd19df3", size = 5587844, upload-time = "2025-11-06T22:07:45.033Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/8e/0c10ff1ea5d4360ab8bfca4cb2c9d979101a391f3e79d2616c9bf348cd26/ruff-0.14.3-py3-none-linux_armv6l.whl", hash = "sha256:876b21e6c824f519446715c1342b8e60f97f93264012de9d8d10314f8a79c371", size = 12535613, upload-time = "2025-10-31T00:25:44.302Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/c8/6724f4634c1daf52409fbf13fefda64aa9c8f81e44727a378b7b73dc590b/ruff-0.14.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b6fd8c79b457bedd2abf2702b9b472147cd860ed7855c73a5247fa55c9117654", size = 12855812, upload-time = "2025-10-31T00:25:47.793Z" },
-    { url = "https://files.pythonhosted.org/packages/de/03/db1bce591d55fd5f8a08bb02517fa0b5097b2ccabd4ea1ee29aa72b67d96/ruff-0.14.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:71ff6edca490c308f083156938c0c1a66907151263c4abdcb588602c6e696a14", size = 11944026, upload-time = "2025-10-31T00:25:49.657Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/75/4f8dbd48e03272715d12c87dc4fcaaf21b913f0affa5f12a4e9c6f8a0582/ruff-0.14.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:786ee3ce6139772ff9272aaf43296d975c0217ee1b97538a98171bf0d21f87ed", size = 12356818, upload-time = "2025-10-31T00:25:51.949Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/9b/506ec5b140c11d44a9a4f284ea7c14ebf6f8b01e6e8917734a3325bff787/ruff-0.14.3-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cd6291d0061811c52b8e392f946889916757610d45d004e41140d81fb6cd5ddc", size = 12336745, upload-time = "2025-10-31T00:25:54.248Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/e1/c560d254048c147f35e7f8131d30bc1f63a008ac61595cf3078a3e93533d/ruff-0.14.3-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a497ec0c3d2c88561b6d90f9c29f5ae68221ac00d471f306fa21fa4264ce5fcd", size = 13101684, upload-time = "2025-10-31T00:25:56.253Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/32/e310133f8af5cd11f8cc30f52522a3ebccc5ea5bff4b492f94faceaca7a8/ruff-0.14.3-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:e231e1be58fc568950a04fbe6887c8e4b85310e7889727e2b81db205c45059eb", size = 14535000, upload-time = "2025-10-31T00:25:58.397Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/a1/7b0470a22158c6d8501eabc5e9b6043c99bede40fa1994cadf6b5c2a61c7/ruff-0.14.3-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:469e35872a09c0e45fecf48dd960bfbce056b5db2d5e6b50eca329b4f853ae20", size = 14156450, upload-time = "2025-10-31T00:26:00.889Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/96/24bfd9d1a7f532b560dcee1a87096332e461354d3882124219bcaff65c09/ruff-0.14.3-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3d6bc90307c469cb9d28b7cfad90aaa600b10d67c6e22026869f585e1e8a2db0", size = 13568414, upload-time = "2025-10-31T00:26:03.291Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/e7/138b883f0dfe4ad5b76b58bf4ae675f4d2176ac2b24bdd81b4d966b28c61/ruff-0.14.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e2f8a0bbcffcfd895df39c9a4ecd59bb80dca03dc43f7fb63e647ed176b741e", size = 13315293, upload-time = "2025-10-31T00:26:05.708Z" },
-    { url = "https://files.pythonhosted.org/packages/33/f4/c09bb898be97b2eb18476b7c950df8815ef14cf956074177e9fbd40b7719/ruff-0.14.3-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:678fdd7c7d2d94851597c23ee6336d25f9930b460b55f8598e011b57c74fd8c5", size = 13539444, upload-time = "2025-10-31T00:26:08.09Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/aa/b30a1db25fc6128b1dd6ff0741fa4abf969ded161599d07ca7edd0739cc0/ruff-0.14.3-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:1ec1ac071e7e37e0221d2f2dbaf90897a988c531a8592a6a5959f0603a1ecf5e", size = 12252581, upload-time = "2025-10-31T00:26:10.297Z" },
-    { url = "https://files.pythonhosted.org/packages/da/13/21096308f384d796ffe3f2960b17054110a9c3828d223ca540c2b7cc670b/ruff-0.14.3-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:afcdc4b5335ef440d19e7df9e8ae2ad9f749352190e96d481dc501b753f0733e", size = 12307503, upload-time = "2025-10-31T00:26:12.646Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/cc/a350bac23f03b7dbcde3c81b154706e80c6f16b06ff1ce28ed07dc7b07b0/ruff-0.14.3-py3-none-musllinux_1_2_i686.whl", hash = "sha256:7bfc42f81862749a7136267a343990f865e71fe2f99cf8d2958f684d23ce3dfa", size = 12675457, upload-time = "2025-10-31T00:26:15.044Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/76/46346029fa2f2078826bc88ef7167e8c198e58fe3126636e52f77488cbba/ruff-0.14.3-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a65e448cfd7e9c59fae8cf37f9221585d3354febaad9a07f29158af1528e165f", size = 13403980, upload-time = "2025-10-31T00:26:17.81Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/a4/35f1ef68c4e7b236d4a5204e3669efdeefaef21f0ff6a456792b3d8be438/ruff-0.14.3-py3-none-win32.whl", hash = "sha256:f3d91857d023ba93e14ed2d462ab62c3428f9bbf2b4fbac50a03ca66d31991f7", size = 12500045, upload-time = "2025-10-31T00:26:20.503Z" },
-    { url = "https://files.pythonhosted.org/packages/03/15/51960ae340823c9859fb60c63301d977308735403e2134e17d1d2858c7fb/ruff-0.14.3-py3-none-win_amd64.whl", hash = "sha256:d7b7006ac0756306db212fd37116cce2bd307e1e109375e1c6c106002df0ae5f", size = 13594005, upload-time = "2025-10-31T00:26:22.533Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/73/4de6579bac8e979fca0a77e54dec1f1e011a0d268165eb8a9bc0982a6564/ruff-0.14.3-py3-none-win_arm64.whl", hash = "sha256:26eb477ede6d399d898791d01961e16b86f02bc2486d0d1a7a9bb2379d055dc1", size = 12590017, upload-time = "2025-10-31T00:26:24.52Z" },
+    { url = "https://files.pythonhosted.org/packages/17/b9/67240254166ae1eaa38dec32265e9153ac53645a6c6670ed36ad00722af8/ruff-0.14.4-py3-none-linux_armv6l.whl", hash = "sha256:e6604613ffbcf2297cd5dcba0e0ac9bd0c11dc026442dfbb614504e87c349518", size = 12606781, upload-time = "2025-11-06T22:07:01.841Z" },
+    { url = "https://files.pythonhosted.org/packages/46/c8/09b3ab245d8652eafe5256ab59718641429f68681ee713ff06c5c549f156/ruff-0.14.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:d99c0b52b6f0598acede45ee78288e5e9b4409d1ce7f661f0fa36d4cbeadf9a4", size = 12946765, upload-time = "2025-11-06T22:07:05.858Z" },
+    { url = "https://files.pythonhosted.org/packages/14/bb/1564b000219144bf5eed2359edc94c3590dd49d510751dad26202c18a17d/ruff-0.14.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:9358d490ec030f1b51d048a7fd6ead418ed0826daf6149e95e30aa67c168af33", size = 11928120, upload-time = "2025-11-06T22:07:08.023Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/92/d5f1770e9988cc0742fefaa351e840d9aef04ec24ae1be36f333f96d5704/ruff-0.14.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:81b40d27924f1f02dfa827b9c0712a13c0e4b108421665322218fc38caf615c2", size = 12370877, upload-time = "2025-11-06T22:07:10.015Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/29/e9282efa55f1973d109faf839a63235575519c8ad278cc87a182a366810e/ruff-0.14.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f5e649052a294fe00818650712083cddc6cc02744afaf37202c65df9ea52efa5", size = 12408538, upload-time = "2025-11-06T22:07:13.085Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/01/930ed6ecfce130144b32d77d8d69f5c610e6d23e6857927150adf5d7379a/ruff-0.14.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aa082a8f878deeba955531f975881828fd6afd90dfa757c2b0808aadb437136e", size = 13141942, upload-time = "2025-11-06T22:07:15.386Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/46/a9c89b42b231a9f487233f17a89cbef9d5acd538d9488687a02ad288fa6b/ruff-0.14.4-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:1043c6811c2419e39011890f14d0a30470f19d47d197c4858b2787dfa698f6c8", size = 14544306, upload-time = "2025-11-06T22:07:17.631Z" },
+    { url = "https://files.pythonhosted.org/packages/78/96/9c6cf86491f2a6d52758b830b89b78c2ae61e8ca66b86bf5a20af73d20e6/ruff-0.14.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a9f3a936ac27fb7c2a93e4f4b943a662775879ac579a433291a6f69428722649", size = 14210427, upload-time = "2025-11-06T22:07:19.832Z" },
+    { url = "https://files.pythonhosted.org/packages/71/f4/0666fe7769a54f63e66404e8ff698de1dcde733e12e2fd1c9c6efb689cb5/ruff-0.14.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:95643ffd209ce78bc113266b88fba3d39e0461f0cbc8b55fb92505030fb4a850", size = 13658488, upload-time = "2025-11-06T22:07:22.32Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/79/6ad4dda2cfd55e41ac9ed6d73ef9ab9475b1eef69f3a85957210c74ba12c/ruff-0.14.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:456daa2fa1021bc86ca857f43fe29d5d8b3f0e55e9f90c58c317c1dcc2afc7b5", size = 13354908, upload-time = "2025-11-06T22:07:24.347Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/60/f0b6990f740bb15c1588601d19d21bcc1bd5de4330a07222041678a8e04f/ruff-0.14.4-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:f911bba769e4a9f51af6e70037bb72b70b45a16db5ce73e1f72aefe6f6d62132", size = 13587803, upload-time = "2025-11-06T22:07:26.327Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/da/eaaada586f80068728338e0ef7f29ab3e4a08a692f92eb901a4f06bbff24/ruff-0.14.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:76158a7369b3979fa878612c623a7e5430c18b2fd1c73b214945c2d06337db67", size = 12279654, upload-time = "2025-11-06T22:07:28.46Z" },
+    { url = "https://files.pythonhosted.org/packages/66/d4/b1d0e82cf9bf8aed10a6d45be47b3f402730aa2c438164424783ac88c0ed/ruff-0.14.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f3b8f3b442d2b14c246e7aeca2e75915159e06a3540e2f4bed9f50d062d24469", size = 12357520, upload-time = "2025-11-06T22:07:31.468Z" },
+    { url = "https://files.pythonhosted.org/packages/04/f4/53e2b42cc82804617e5c7950b7079d79996c27e99c4652131c6a1100657f/ruff-0.14.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c62da9a06779deecf4d17ed04939ae8b31b517643b26370c3be1d26f3ef7dbde", size = 12719431, upload-time = "2025-11-06T22:07:33.831Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/94/80e3d74ed9a72d64e94a7b7706b1c1ebaa315ef2076fd33581f6a1cd2f95/ruff-0.14.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5a443a83a1506c684e98acb8cb55abaf3ef725078be40237463dae4463366349", size = 13464394, upload-time = "2025-11-06T22:07:35.905Z" },
+    { url = "https://files.pythonhosted.org/packages/54/1a/a49f071f04c42345c793d22f6cf5e0920095e286119ee53a64a3a3004825/ruff-0.14.4-py3-none-win32.whl", hash = "sha256:643b69cb63cd996f1fc7229da726d07ac307eae442dd8974dbc7cf22c1e18fff", size = 12493429, upload-time = "2025-11-06T22:07:38.43Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/22/e58c43e641145a2b670328fb98bc384e20679b5774258b1e540207580266/ruff-0.14.4-py3-none-win_amd64.whl", hash = "sha256:26673da283b96fe35fa0c939bf8411abec47111644aa9f7cfbd3c573fb125d2c", size = 13635380, upload-time = "2025-11-06T22:07:40.496Z" },
+    { url = "https://files.pythonhosted.org/packages/30/bd/4168a751ddbbf43e86544b4de8b5c3b7be8d7167a2a5cb977d274e04f0a1/ruff-0.14.4-py3-none-win_arm64.whl", hash = "sha256:dd09c292479596b0e6fec8cd95c65c3a6dc68e9ad17b8f2382130f87ff6a75bb", size = 12663065, upload-time = "2025-11-06T22:07:42.603Z" },
 ]
 
 [[package]]
@@ -1282,7 +1282,6 @@ dependencies = [
     { name = "aiosqlite" },
     { name = "alembic" },
     { name = "assemblyai" },
-    { name = "boto3" },
     { name = "fastapi" },
     { name = "google-genai" },
     { name = "httpx" },
@@ -1311,7 +1310,6 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.13.0" },
     { name = "assemblyai", specifier = ">=0.30.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=25.9.0" },
-    { name = "boto3", specifier = ">=1.34.0" },
     { name = "fastapi", specifier = ">=0.121.0" },
     { name = "google-genai", specifier = ">=1.49.0" },
     { name = "httpx", specifier = ">=0.28.1" },
@@ -1323,7 +1321,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "python-multipart", specifier = ">=0.0.6" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.3" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.4" },
     { name = "sqlalchemy", specifier = ">=2.0.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.38.0" },
 ]


### PR DESCRIPTION
## Summary
Refactored settings management to follow FastAPI's official recommended pattern using dependency injection with `@lru_cache`.

## Changes

### Core Refactoring
- Added `@lru_cache` to `get_settings()` for singleton pattern
- Updated endpoints to use `Depends(get_settings)` for config injection  
- Kept module-level `settings` for backward compatibility
- Updated service functions to accept optional `settings` parameter

### Updated Files
**Application Code (14 files):**
- `app/core/config.py` - Added `get_settings()` with `@lru_cache`
- `app/api/v1/health.py` - Use dependency injection
- `app/api/v1/transcription.py` - Use dependency injection
- `app/api/v1/translation.py` - Pass settings to service functions
- `app/core/logging.py` - Call `get_settings()`
- `app/core/middleware.py` - Call `get_settings()`
- `app/core/security.py` - Call `get_settings()`
- `app/db/base.py` - Cache settings at module level
- `app/main.py` - Call `get_settings()` for app creation
- `app/services/translation.py` - Accept optional settings parameter
- `app/services/transcription_service.py` - Call `get_settings()`
- `app/services/assemblyai_client.py` - Call `get_settings()`
- `app/services/polling_service.py` - Call `get_settings()`
- `app/storage/s3.py` - Call `get_settings()` in `__init__`

**Tests (7 files):**
- Updated all tests to use `Settings` instances or patch `get_settings()`
- Fixed 213 tests across transcription, translation, S3, security, and polling

## Benefits
- **Better testability** via dependency injection
- **FastAPI idiomatic** pattern (official recommendation)
- **Cached settings** instance for performance (`@lru_cache`)
- **Easier to override** settings per context
- **Backward compatible** with module-level `settings`

## Testing
- ✅ All 213 tests passing
- ✅ No performance regression
- ✅ Backward compatibility maintained

## References
- [FastAPI Advanced Settings](https://fastapi.tiangolo.com/advanced/settings)